### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgde"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Paul Caruso <crusopaul@gmail.com>"]
 license = "MIT"
 edition = "2021"
@@ -19,16 +19,16 @@ json = ["serde_json", "tokio-postgres/with-serde_json-1"]
 uuid = ["dep:uuid", "tokio-postgres/with-uuid-1"]
 
 [dependencies]
-bit-vec = { version = "0.6.0", optional = true }
-chrono = { version = "0.4.0", optional = true }
-eui48 = { version = "1.1.0", optional = true }
-geo-types = { version = "0.7.13", optional = true }
-pgde_derive = { version = "0.2.0" }
-serde = { version = "1.0.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0.0", optional = true }
-tokio-postgres = { version = "0.7.0" }
-uuid = { version = "1.8.0", features = ["v4"], optional = true }
+bit-vec = { version = "0.6", optional = true }
+chrono = { version = "0.4", optional = true }
+eui48 = { version = "1.1", optional = true }
+geo-types = { version = "0.7", optional = true }
+pgde_derive = { version = "0.2" }
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+tokio-postgres = { version = "0.7" }
+uuid = { version = "1.10", features = ["v4"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", features = ["full"] }
-tokio-test = { version = "0.4.4" }
+tokio = { version = "1.38", features = ["full"] }
+tokio-test = { version = "0.4" }


### PR DESCRIPTION
Updated `uuid` from 1.8 -> 1.10. Changed formatting for dependencies in cargo.toml to be less restrictive