### PR TITLE
Add bit-vec 0.7 and 0.8 support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,10 @@ jobs:
         cargo build -Ftime_0_3
         cargo build -Fuuid_1
     - name: Build all features
-      run: cargo build --all-features
+      run: |
+        cargo build -Fbit_0_6 -Fchrono_0_4 -Fconsume_json_1 -Fgeo_0_7 -Fmac_1 -Fjson_1 -Ftime_0_3 -Fuuid_1
+        cargo build -Fbit_0_7 -Fchrono_0_4 -Fconsume_json_1 -Fgeo_0_7 -Fmac_1 -Fjson_1 -Ftime_0_3 -Fuuid_1
+        cargo build -Fbit_0_8 -Fchrono_0_4 -Fconsume_json_1 -Fgeo_0_7 -Fmac_1 -Fjson_1 -Ftime_0_3 -Fuuid_1
     - name: Test base
       run: cargo test --tests
     - name: Test features independently

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,4 +63,7 @@ jobs:
         cargo test -Ftime_0_3
         cargo test -Fuuid_1
     - name: Test all features
-      run: cargo test --all-features
+      run: |
+        cargo test -Fbit_0_6 -Fchrono_0_4 -Fconsume_json_1 -Fgeo_0_7 -Fmac_1 -Fjson_1 -Ftime_0_3 -Fuuid_1
+        cargo test -Fbit_0_7 -Fchrono_0_4 -Fconsume_json_1 -Fgeo_0_7 -Fmac_1 -Fjson_1 -Ftime_0_3 -Fuuid_1
+        cargo test -Fbit_0_8 -Fchrono_0_4 -Fconsume_json_1 -Fgeo_0_7 -Fmac_1 -Fjson_1 -Ftime_0_3 -Fuuid_1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,27 +36,31 @@ jobs:
       run: cargo build
     - name: Build features independently
       run: |
-        cargo build -Fbit
-        cargo build -Fchrono
-        cargo build -Fconsume_json
-        cargo build -Fgeo
-        cargo build -Fmac
-        cargo build -Fjson
-        cargo build -Ftime
-        cargo build -Fuuid
+        cargo build -Fbit_0_6
+        cargo build -Fbit_0_7
+        cargo build -Fbit_0_8
+        cargo build -Fchrono_0_4
+        cargo build -Fconsume_json_1
+        cargo build -Fgeo_0_7
+        cargo build -Fmac_1
+        cargo build -Fjson_1
+        cargo build -Ftime_0_3
+        cargo build -Fuuid_1
     - name: Build all features
       run: cargo build --all-features
     - name: Test base
       run: cargo test --tests
     - name: Test features independently
       run: |
-        cargo test -Fbit
-        cargo test -Fchrono
-        cargo test -Fconsume_json
-        cargo test -Fgeo
-        cargo test -Fmac
-        cargo test -Fjson
-        cargo test -Ftime
-        cargo test -Fuuid
+        cargo test -Fbit_0_6
+        cargo test -Fbit_0_7
+        cargo test -Fbit_0_8
+        cargo test -Fchrono_0_4
+        cargo test -Fconsume_json_1
+        cargo test -Fgeo_0_7
+        cargo test -Fmac_1
+        cargo test -Fjson_1
+        cargo test -Ftime_0_3
+        cargo test -Fuuid_1
     - name: Test all features
       run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ description = "A macro library for consuming PostgreSQL row data into structs."
 readme = "README.md"
 categories = [ "api-bindings", "development-tools::ffi", "rust-patterns" ]
 keywords = ["postgresql"]
+
+[lib]
 doctest = false
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgde"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Paul Caruso <crusopaul@gmail.com>"]
 license = "MIT"
 edition = "2021"
@@ -11,28 +11,32 @@ categories = [ "api-bindings", "development-tools::ffi", "rust-patterns" ]
 keywords = ["postgresql"]
 
 [features]
-bit = ["dep:bit-vec", "tokio-postgres/with-bit-vec-0_6"]
-chrono = ["dep:chrono", "tokio-postgres/with-chrono-0_4"]
-consume_json = ["dep:serde", "dep:serde_json"]
-geo = ["dep:geo-types", "tokio-postgres/with-geo-types-0_7"]
-mac = ["dep:eui48", "tokio-postgres/with-eui48-1"]
-json = ["dep:serde_json", "tokio-postgres/with-serde_json-1"]
-time = ["dep:time", "tokio-postgres/with-time-0_3"]
-uuid = ["dep:uuid", "tokio-postgres/with-uuid-1"]
+bit_0_6 = ["dep:bit-vec_0_6", "tokio-postgres/with-bit-vec-0_6"]
+bit_0_7 = ["dep:bit-vec_0_7", "tokio-postgres/with-bit-vec-0_7"]
+bit_0_8 = ["dep:bit-vec_0_8", "tokio-postgres/with-bit-vec-0_8"]
+chrono_0_4 = ["dep:chrono_0_4", "tokio-postgres/with-chrono-0_4"]
+consume_json_1 = ["dep:serde_1", "dep:serde_json_1"]
+geo_0_7 = ["dep:geo-types_0_7", "tokio-postgres/with-geo-types-0_7"]
+mac_1 = ["dep:eui48_1", "tokio-postgres/with-eui48-1"]
+json_1 = ["dep:serde_json_1", "tokio-postgres/with-serde_json-1"]
+time_0_3 = ["dep:time_0_3", "tokio-postgres/with-time-0_3"]
+uuid_1 = ["dep:uuid_1", "tokio-postgres/with-uuid-1"]
 
 [dependencies]
-bit-vec = { version = "0.6", optional = true }
-chrono = { version = "0.4", optional = true }
-eui48 = { version = "1.1", optional = true }
-geo-types = { version = "0.7", optional = true }
+bit-vec_0_6 = { package = "bit-vec", version = "0.6", optional = true }
+bit-vec_0_7 = { package = "bit-vec", version = "0.7", optional = true }
+bit-vec_0_8 = { package = "bit-vec", version = "0.8", optional = true }
+chrono_0_4 = { package = "chrono", version = "0.4", optional = true }
+eui48_1 = { package = "eui48", version = "1.1", optional = true }
+geo-types_0_7 = { package = "geo-types", version = "0.7", optional = true }
 pgde_derive = { version = "0.2" }
-serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
-time = { version = "0.3", optional = true }
+serde_1 = { package = "serde", version = "1.0", features = ["derive"], optional = true }
+serde_json_1 = { package = "serde_json", version = "1.0", optional = true }
+time_0_3 = { package = "time", version = "0.3", optional = true }
 tokio-postgres = { version = "0.7" }
-uuid = { version = "1.10", features = ["v4"], optional = true }
+uuid_1 = { package = "uuid", version = "1.0", features = ["v4"], optional = true }
 
 [dev-dependencies]
-time = { version = "0.3", features = ["macros"] }
+time_0_3 = { package = "time", version = "0.3", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
 tokio-test = { version = "0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "A macro library for consuming PostgreSQL row data into structs."
 readme = "README.md"
 categories = [ "api-bindings", "development-tools::ffi", "rust-patterns" ]
 keywords = ["postgresql"]
+doctest = false
 
 [features]
 bit_0_6 = ["dep:bit-vec_0_6", "tokio-postgres/with-bit-vec-0_6"]

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ A variety of features provide support for additional implementation and types.
 
 | Feature | Description | Extra dependencies | Default |
 | ------- | ----------- | ------------------ | ------- |
-| `bit` | Implements crate on `bit_vec::BitVec` | bit-vec | No |
-| `chrono` | Implements crate on types supplied by chrono | chrono | No |
-| `consume_json` | Implements `consume_json` on classes that derive the `RowConsumer` trait | serde, serde_json | No |
-| `geo` | Implements crate on `geo_types::Point<f64>`, `geo_types::Rect<f64>`, and `geo_types::LineString<f64>` | geo-types | No |
-| `mac` | Implements crate on `eui48::MacAddress` | eui48 | No |
-| `json` | Implements crate on `serde_json::Value` | serde_json | No |
-| `time` | Implements crate on types supplied by time | time | No |
-| `uuid` | Implements crate on `uuid::Uuid` | uuid | No |
+| `bit_{0_6, 0_7, 0_8}` | Implements crate on `bit_vec::BitVec` | bit-vec | No |
+| `chrono_0_4` | Implements crate on types supplied by chrono | chrono | No |
+| `consume_json_1` | Implements `consume_json` on classes that derive the `RowConsumer` trait | serde, serde_json | No |
+| `geo_0_7` | Implements crate on `geo_types::Point<f64>`, `geo_types::Rect<f64>`, and `geo_types::LineString<f64>` | geo-types | No |
+| `mac_1` | Implements crate on `eui48::MacAddress` | eui48 | No |
+| `json_1` | Implements crate on `serde_json::Value` | serde_json | No |
+| `time_0_3` | Implements crate on types supplied by time | time | No |
+| `uuid_1` | Implements crate on `uuid::Uuid` | uuid | No |
 
 ## Examples
 You may use `consume` to consume PostgreSQL row data into a struct like so.
@@ -87,23 +87,23 @@ This crate also provides implementations on a variety of data types, some provid
 | `String` | `default` |
 | `SystemTime` | `default` |
 | `IpAddr` | `default` |
-| `bit_vec::BitVec` | `bit` |
-| `chrono::NaiveDateTime` | `chrono` |
-| `chrono::DateTime<Utc>` | `chrono` |
-| `chrono::DateTime<Local>` | `chrono` |
-| `chrono::DateTime<FixedOffset>` | `chrono` |
-| `chrono::NaiveDate` | `chrono` |
-| `chrono::NaiveTime` | `chrono` |
-| `geo_types::Point<f64>` | `geo` |
-| `geo_types::Rect<f64>` | `geo` |
-| `geo_types::LineString<f64>` | `geo` |
-| `eui48::MacAddress` | `mac` |
-| `serde_json::Value` | `json` |
-| `time::PrimitiveDateTime` | `time` |
-| `time::OffsetDateTime` | `time` |
-| `time::Date` | `time` |
-| `time::Time` | `time` |
-| `uuid::Uuid` | `uuid` |
+| `bit_vec::BitVec` | `bit_{0_6, 0_7, 0_8}` |
+| `chrono::NaiveDateTime` | `chrono_0_4` |
+| `chrono::DateTime<Utc>` | `chrono_0_4` |
+| `chrono::DateTime<Local>` | `chrono_0_4` |
+| `chrono::DateTime<FixedOffset>` | `chrono_0_4` |
+| `chrono::NaiveDate` | `chrono_0_4` |
+| `chrono::NaiveTime` | `chrono_0_4` |
+| `geo_types::Point<f64>` | `geo_0_7` |
+| `geo_types::Rect<f64>` | `geo_0_7` |
+| `geo_types::LineString<f64>` | `geo_0_7` |
+| `eui48::MacAddress` | `mac_1` |
+| `serde_json::Value` | `json_1` |
+| `time::PrimitiveDateTime` | `time_0_3` |
+| `time::OffsetDateTime` | `time_0_3` |
+| `time::Date` | `time_0_3` |
+| `time::Time` | `time_0_3` |
+| `uuid::Uuid` | `uuid_1` |
 
 ## Testing
 Testing requires access to a PostgreSQL database with no tables. Setting the following environment variables will allow you to test.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,11 +370,10 @@ pub trait RowConsumer {
     /// use pgde::ConsumeError;
     /// use pgde::RowConsumer;
     /// use pgde_derive::RowConsumer;
-    /// use serde_1::{self, Serialize};
+    /// use serde::Serialize;
     /// use tokio_postgres::{NoTls, Row};
     ///
     /// #[derive(Serialize, RowConsumer)]
-    /// #[serde(crate = "self::serde_1")]
     /// struct Foo {
     ///     Id: i32,
     ///     Data: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ use geo_types_0_7::Point;
 #[cfg(feature = "geo_0_7")]
 use geo_types_0_7::Rect;
 #[cfg(feature = "consume_json_1")]
-use serde_1::Serialize;
+use serde_1::{self, Serialize};
 use std::future::Future;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
@@ -370,10 +370,11 @@ pub trait RowConsumer {
     /// use pgde::ConsumeError;
     /// use pgde::RowConsumer;
     /// use pgde_derive::RowConsumer;
-    /// use serde::Serialize;
+    /// use serde_1::{self, Serialize};
     /// use tokio_postgres::{NoTls, Row};
     ///
     /// #[derive(Serialize, RowConsumer)]
+    /// #[serde(crate = "self::serde_1")]
     /// struct Foo {
     ///     Id: i32,
     ///     Data: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,14 @@
 //!
 //! | Feature | Description | Extra dependencies | Default |
 //! | ------- | ----------- | ------------------ | ------- |
-//! | `bit` | Implements crate on `bit_vec::BitVec` | bit-vec | No |
-//! | `chrono` | Implements crate on types supplied by chrono | chrono | No |
-//! | `consume_json` | Implements `consume_json` on classes that derive the `RowConsumer` trait | serde, serde_json | No |
-//! | `geo` | Implements crate on `geo_types::Point<f64>`, `geo_types::Rect<f64>`, and `geo_types::LineString<f64>` | geo-types | No |
-//! | `mac` | Implements crate on `eui48::MacAddress` | eui48 | No |
-//! | `json` | Implements crate on `serde_json::Value` | serde_json | No |
-//! | `time` | Implements crate on types supplied by time | time | No |
-//! | `uuid` | Implements crate on `uuid::Uuid` | uuid | No |
+//! | `bit_{0_6, 0_7, 0_8}` | Implements crate on `bit_vec::BitVec` | bit-vec | No |
+//! | `chrono_0_4` | Implements crate on types supplied by chrono | chrono | No |
+//! | `consume_json_1` | Implements `consume_json` on classes that derive the `RowConsumer` trait | serde, serde_json | No |
+//! | `geo_0_7` | Implements crate on `geo_types::Point<f64>`, `geo_types::Rect<f64>`, and `geo_types::LineString<f64>` | geo-types | No |
+//! | `mac_1` | Implements crate on `eui48::MacAddress` | eui48 | No |
+//! | `json_1` | Implements crate on `serde_json::Value` | serde_json | No |
+//! | `time_0_3` | Implements crate on types supplied by time | time | No |
+//! | `uuid_1` | Implements crate on `uuid::Uuid` | uuid | No |
 //!
 //! ## Examples
 //! You may use `consume` to consume PostgreSQL row data into a struct like so.
@@ -87,23 +87,23 @@
 //! | `String` | `default` |
 //! | `SystemTime` | `default` |
 //! | `IpAddr` | `default` |
-//! | `bit_vec::BitVec` | `bit` |
-//! | `chrono::NaiveDateTime` | `chrono` |
-//! | `chrono::DateTime<Utc>` | `chrono` |
-//! | `chrono::DateTime<Local>` | `chrono` |
-//! | `chrono::DateTime<FixedOffset>` | `chrono` |
-//! | `chrono::NaiveDate` | `chrono` |
-//! | `chrono::NaiveTime` | `chrono` |
-//! | `geo_types::Point<f64>` | `geo` |
-//! | `geo_types::Rect<f64>` | `geo` |
-//! | `geo_types::LineString<f64>` | `geo` |
-//! | `eui48::MacAddress` | `mac` |
-//! | `serde_json::Value` | `json` |
-//! | `time::PrimitiveDateTime` | `time` |
-//! | `time::OffsetDateTime` | `time` |
-//! | `time::Date` | `time` |
-//! | `time::Time` | `time` |
-//! | `uuid::Uuid` | `uuid` |
+//! | `bit_vec::BitVec` | `bit_{0_6, 0_7, 0_8}` |
+//! | `chrono::NaiveDateTime` | `chrono_0_4` |
+//! | `chrono::DateTime<Utc>` | `chrono_0_4` |
+//! | `chrono::DateTime<Local>` | `chrono_0_4` |
+//! | `chrono::DateTime<FixedOffset>` | `chrono_0_4` |
+//! | `chrono::NaiveDate` | `chrono_0_4` |
+//! | `chrono::NaiveTime` | `chrono_0_4` |
+//! | `geo_types::Point<f64>` | `geo_0_7` |
+//! | `geo_types::Rect<f64>` | `geo_0_7` |
+//! | `geo_types::LineString<f64>` | `geo_0_7` |
+//! | `eui48::MacAddress` | `mac_1` |
+//! | `serde_json::Value` | `json_1` |
+//! | `time::PrimitiveDateTime` | `time_0_3` |
+//! | `time::OffsetDateTime` | `time_0_3` |
+//! | `time::Date` | `time_0_3` |
+//! | `time::Time` | `time_0_3` |
+//! | `uuid::Uuid` | `uuid_1` |
 //!
 //! ## Testing
 //! Testing requires access to a PostgreSQL database with no tables. Setting the following environment variables will allow you to test.
@@ -114,34 +114,38 @@
 //! | `POSTGRES_USER` | The user credential to provide. |
 //! | `POSTGRES_PASSWORD` | The password to provide. |
 //! | `POSTGRES_DB` | The name of the database to use for testing. |
-#[cfg(feature = "bit")]
+#[cfg(feature = "bit_0_6")]
 use bit_vec::BitVec;
-#[cfg(feature = "chrono")]
+#[cfg(feature = "bit_0_7")]
+use bit_vec::BitVec;
+#[cfg(feature = "bit_0_8")]
+use bit_vec::BitVec;
+#[cfg(feature = "chrono_0_4")]
 use chrono::prelude::*;
-#[cfg(feature = "mac")]
+#[cfg(feature = "mac_1")]
 use eui48::MacAddress;
-#[cfg(feature = "geo")]
+#[cfg(feature = "geo_0_7")]
 use geo_types::coord;
-#[cfg(feature = "geo")]
+#[cfg(feature = "geo_0_7")]
 use geo_types::line_string;
-#[cfg(feature = "geo")]
+#[cfg(feature = "geo_0_7")]
 use geo_types::LineString;
-#[cfg(feature = "geo")]
+#[cfg(feature = "geo_0_7")]
 use geo_types::Point;
-#[cfg(feature = "geo")]
+#[cfg(feature = "geo_0_7")]
 use geo_types::Rect;
-#[cfg(feature = "consume_json")]
+#[cfg(feature = "consume_json_1")]
 use serde::Serialize;
 use std::future::Future;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::time::SystemTime;
-#[cfg(feature = "time")]
+#[cfg(feature = "time_0_3")]
 use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
 use tokio_postgres::row::Row;
 use tokio_postgres::types::ToSql;
 use tokio_postgres::Client;
-#[cfg(feature = "uuid")]
+#[cfg(feature = "uuid_1")]
 use uuid::Uuid;
 
 /// Errors that may occur during row consumption.
@@ -399,7 +403,7 @@ pub trait RowConsumer {
     /// };
     /// # })
     /// ```
-    #[cfg(feature = "consume_json")]
+    #[cfg(feature = "consume_json_1")]
     fn consume_json(
         conn: &Client,
         query: &str,
@@ -527,10 +531,14 @@ pg_type_expr_implementation![
     Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
 ];
 
-#[cfg(feature = "bit")]
+#[cfg(feature = "bit_0_6")]
+pg_type_implementation![BitVec, Vec<BitVec>, Option<BitVec>];
+#[cfg(feature = "bit_0_7")]
+pg_type_implementation![BitVec, Vec<BitVec>, Option<BitVec>];
+#[cfg(feature = "bit_0_8")]
 pg_type_implementation![BitVec, Vec<BitVec>, Option<BitVec>];
 
-#[cfg(feature = "chrono")]
+#[cfg(feature = "chrono_0_4")]
 pg_type_implementation![
     NaiveDateTime,
     DateTime<Utc>,
@@ -552,10 +560,10 @@ pg_type_implementation![
     Option<NaiveTime>
 ];
 
-#[cfg(feature = "geo")]
+#[cfg(feature = "geo_0_7")]
 pg_type_implementation![Point<f64>, Vec<Point<f64>>, Option<Point<f64>>];
 
-#[cfg(feature = "geo")]
+#[cfg(feature = "geo_0_7")]
 pg_type_expr_implementation![
     Rect<f64>,
     Rect::new(coord! { x: 0., y: 0.}, coord! { x: 1., y: 1.},),
@@ -580,10 +588,10 @@ pg_type_expr_implementation![
     ])
 ];
 
-#[cfg(feature = "mac")]
+#[cfg(feature = "mac_1")]
 pg_type_implementation![MacAddress, Vec<MacAddress>, Option<MacAddress>];
 
-#[cfg(feature = "time")]
+#[cfg(feature = "time_0_3")]
 pg_type_expr_implementation![
     PrimitiveDateTime,
     PrimitiveDateTime::MIN,
@@ -611,10 +619,10 @@ pg_type_expr_implementation![
     Some(Time::MIDNIGHT)
 ];
 
-#[cfg(feature = "uuid")]
+#[cfg(feature = "uuid_1")]
 pg_type_implementation![Uuid, Vec<Uuid>, Option<Uuid>];
 
-#[cfg(feature = "json")]
+#[cfg(feature = "json_1")]
 pg_type_implementation![
     serde_json::Value,
     Vec<serde_json::Value>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,32 +121,32 @@ use bit_vec_0_7::BitVec;
 #[cfg(feature = "bit_0_8")]
 use bit_vec_0_8::BitVec;
 #[cfg(feature = "chrono_0_4")]
-use chrono::prelude::*;
+use chrono_0_4::prelude::*;
 #[cfg(feature = "mac_1")]
-use eui48::MacAddress;
+use eui48_1::MacAddress;
 #[cfg(feature = "geo_0_7")]
-use geo_types::coord;
+use geo_types_0_7::coord;
 #[cfg(feature = "geo_0_7")]
-use geo_types::line_string;
+use geo_types_0_7::line_string;
 #[cfg(feature = "geo_0_7")]
-use geo_types::LineString;
+use geo_types_0_7::LineString;
 #[cfg(feature = "geo_0_7")]
-use geo_types::Point;
+use geo_types_0_7::Point;
 #[cfg(feature = "geo_0_7")]
-use geo_types::Rect;
+use geo_types_0_7::Rect;
 #[cfg(feature = "consume_json_1")]
-use serde::Serialize;
+use serde_1::Serialize;
 use std::future::Future;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::time::SystemTime;
 #[cfg(feature = "time_0_3")]
-use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
+use time_0_3::{Date, OffsetDateTime, PrimitiveDateTime, Time};
 use tokio_postgres::row::Row;
 use tokio_postgres::types::ToSql;
 use tokio_postgres::Client;
 #[cfg(feature = "uuid_1")]
-use uuid::Uuid;
+use uuid_1::Uuid;
 
 /// Errors that may occur during row consumption.
 pub enum ConsumeError {
@@ -414,11 +414,11 @@ pub trait RowConsumer {
     {
         async move {
             match &Self::consume(conn, query, params).await {
-                Ok(v) => match serde_json::to_string(v) {
+                Ok(v) => match serde_json_1::to_string(v) {
                     Ok(v) => Ok(v),
-                    Err(_) => Err(serde_json::Value::default().to_string()),
+                    Err(_) => Err(serde_json_1::Value::default().to_string()),
                 },
-                Err(_) => Err(serde_json::Value::default().to_string()),
+                Err(_) => Err(serde_json_1::Value::default().to_string()),
             }
         }
     }
@@ -624,7 +624,7 @@ pg_type_implementation![Uuid, Vec<Uuid>, Option<Uuid>];
 
 #[cfg(feature = "json_1")]
 pg_type_implementation![
-    serde_json::Value,
-    Vec<serde_json::Value>,
-    Option<serde_json::Value>
+    serde_json_1::Value,
+    Vec<serde_json_1::Value>,
+    Option<serde_json_1::Value>
 ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,11 +115,11 @@
 //! | `POSTGRES_PASSWORD` | The password to provide. |
 //! | `POSTGRES_DB` | The name of the database to use for testing. |
 #[cfg(feature = "bit_0_6")]
-use bit_vec::BitVec;
+use bit_vec_0_6::BitVec;
 #[cfg(feature = "bit_0_7")]
-use bit_vec::BitVec;
+use bit_vec_0_7::BitVec;
 #[cfg(feature = "bit_0_8")]
-use bit_vec::BitVec;
+use bit_vec_0_8::BitVec;
 #[cfg(feature = "chrono_0_4")]
 use chrono::prelude::*;
 #[cfg(feature = "mac_1")]

--- a/tests/consume.rs
+++ b/tests/consume.rs
@@ -1817,7 +1817,9 @@ async fn consume_time_primitivedatetime() -> Result<(), String> {
             .await
         {
             Ok(_) => {
-                let test_datetime = Date::from_calendar_date(2020, Month::January, 1).unwrap().midnight();
+                let test_datetime = Date::from_calendar_date(2020, Month::January, 1)
+                    .unwrap()
+                    .midnight();
 
                 match v
                     .query(
@@ -1876,7 +1878,10 @@ async fn consume_time_offsetdatetime() -> Result<(), String> {
             .await
         {
             Ok(_) => {
-                let test_datetime = Date::from_calendar_date(2020, Month::January, 1).unwrap().midnight().assume_utc();
+                let test_datetime = Date::from_calendar_date(2020, Month::January, 1)
+                    .unwrap()
+                    .midnight()
+                    .assume_utc();
 
                 match v
                     .query(

--- a/tests/consume.rs
+++ b/tests/consume.rs
@@ -20,7 +20,7 @@ use geo_types_0_7::Rect;
 use pgde::RowConsumer;
 use pgde_derive::RowConsumer;
 #[cfg(feature = "consume_json_1")]
-use serde_1::Serialize;
+use serde_1::{self, Serialize};
 #[cfg(feature = "json_1")]
 use serde_json_1::json;
 use std::net::IpAddr;
@@ -1379,6 +1379,7 @@ async fn consume_json_impl() -> Result<(), String> {
     db_env_assertion!();
 
     #[derive(Serialize, RowConsumer)]
+    #[serde(crate = "self::serde_1")]
     struct Foo {
         foo: i32,
         bar: i32,

--- a/tests/consume.rs
+++ b/tests/consume.rs
@@ -1,37 +1,37 @@
 //! Attempts to test a variety of `consume` scenarios for data types mentioned in the provided `FromSql` type implementations from postgres_types.
 #[cfg(feature = "bit_0_6")]
-use bit_vec::BitVec;
+use bit_vec_0_6::BitVec;
 #[cfg(feature = "bit_0_7")]
-use bit_vec::BitVec;
+use bit_vec_0_7::BitVec;
 #[cfg(feature = "bit_0_8")]
-use bit_vec::BitVec;
+use bit_vec_0_8::BitVec;
 #[cfg(feature = "chrono_0_4")]
-use chrono::prelude::*;
+use chrono_0_4::prelude::*;
 #[cfg(feature = "mac_1")]
-use eui48::MacAddress;
+use eui48_1::MacAddress;
 #[cfg(feature = "geo_0_7")]
-use geo_types::coord;
+use geo_types_0_7::coord;
 #[cfg(feature = "geo_0_7")]
-use geo_types::line_string;
+use geo_types_0_7::line_string;
 #[cfg(feature = "geo_0_7")]
-use geo_types::point;
+use geo_types_0_7::point;
 #[cfg(feature = "geo_0_7")]
-use geo_types::Rect;
+use geo_types_0_7::Rect;
 use pgde::RowConsumer;
 use pgde_derive::RowConsumer;
 #[cfg(feature = "consume_json_1")]
-use serde::Serialize;
+use serde_1::Serialize;
 #[cfg(feature = "json_1")]
-use serde_json::json;
+use serde_json_1::json;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::time::SystemTime;
 #[cfg(feature = "time_0_3")]
-use time::{macros::*, Date, OffsetDateTime, PrimitiveDateTime, Time};
+use time_0_3::{macros::*, Date, OffsetDateTime, PrimitiveDateTime, Time};
 use tokio_postgres::Row;
 use tokio_postgres::{Client, NoTls};
 #[cfg(feature = "uuid_1")]
-use uuid::Uuid;
+use uuid_1::Uuid;
 
 #[macro_export]
 macro_rules! db_env_assertion {

--- a/tests/consume.rs
+++ b/tests/consume.rs
@@ -27,7 +27,7 @@ use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::time::SystemTime;
 #[cfg(feature = "time_0_3")]
-use time_0_3::{macros::*, Date, OffsetDateTime, PrimitiveDateTime, Time};
+use time_0_3::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
 use tokio_postgres::Row;
 use tokio_postgres::{Client, NoTls};
 #[cfg(feature = "uuid_1")]
@@ -843,7 +843,7 @@ async fn consume_point() -> Result<(), String> {
                     .await
                 {
                     Ok(_) => {
-                        match geo_types::Point::<f64>::consume(
+                        match geo_types_0_7::Point::<f64>::consume(
                             &v,
                             "select field1 from public.\"consume_point\";",
                             &[],
@@ -901,7 +901,7 @@ async fn consume_rect() -> Result<(), String> {
                     .await
                 {
                     Ok(_) => {
-                        match geo_types::Rect::<f64>::consume(
+                        match geo_types_0_7::Rect::<f64>::consume(
                             &v,
                             "select field1 from public.\"consume_rect\";",
                             &[],
@@ -960,7 +960,7 @@ async fn consume_linestring() -> Result<(), String> {
                     .await
                 {
                     Ok(_) => {
-                        match geo_types::LineString::<f64>::consume(
+                        match geo_types_0_7::LineString::<f64>::consume(
                             &v,
                             "select field1 from public.\"consume_linestring\";",
                             &[],
@@ -1028,7 +1028,7 @@ async fn consume_json() -> Result<(), String> {
                     .await
                 {
                     Ok(_) => {
-                        match serde_json::Value::consume(
+                        match serde_json_1::Value::consume(
                             &v,
                             "select field1 from public.\"consume_json\";",
                             &[],
@@ -1042,7 +1042,7 @@ async fn consume_json() -> Result<(), String> {
                                         "Could not consume json into Value"
                                     );
 
-                                    match serde_json::Value::consume(
+                                    match serde_json_1::Value::consume(
                                         &v,
                                         "select field2 from public.\"consume_json\";",
                                         &[],
@@ -1817,7 +1817,7 @@ async fn consume_time_primitivedatetime() -> Result<(), String> {
             .await
         {
             Ok(_) => {
-                let test_datetime = datetime!(2020-01-01 0:00);
+                let test_datetime = Date::from_calendar_date(2020, Month::January, 1).unwrap().midnight();
 
                 match v
                     .query(
@@ -1876,7 +1876,7 @@ async fn consume_time_offsetdatetime() -> Result<(), String> {
             .await
         {
             Ok(_) => {
-                let test_datetime = datetime!(2020-01-01 0:00 UTC);
+                let test_datetime = Date::from_calendar_date(2020, Month::January, 1).unwrap().midnight().assume_utc();
 
                 match v
                     .query(
@@ -1935,7 +1935,7 @@ async fn consume_time_date() -> Result<(), String> {
             .await
         {
             Ok(_) => {
-                let test_date = date!(2020 - 01 - 01);
+                let test_date = Date::from_calendar_date(2020, Month::January, 1).unwrap();
 
                 match v
                     .query(
@@ -1990,7 +1990,7 @@ async fn consume_time_time() -> Result<(), String> {
             .await
         {
             Ok(_) => {
-                let test_time = time!(5:00);
+                let test_time = Time::from_hms(5, 0, 0).unwrap();
 
                 match v
                     .query(


### PR DESCRIPTION
- Added version specifiers to current features so that future updates allow for ease of backward compatibility.